### PR TITLE
fix: hydration error

### DIFF
--- a/src/components/cards/log-card.tsx
+++ b/src/components/cards/log-card.tsx
@@ -4,11 +4,6 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import { LightbulbOff } from "lucide-react";
 import { Circle } from "lucide-react";
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/components/ui/hover-card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
 type CardProps = {
@@ -34,7 +29,7 @@ export function LogCard({ ...props }: CardProps) {
   }, [props.created_id]);
 
   return (
-    <Link href={`/logs/${props.log_id}`} passHref>
+    <Link href={`/logs/update/${props.log_id}`}>
       <div className="w-80 h-28 group rounded-md cursor-pointer bg-[#E4E7EC]/10 border hover:border-neutral-400 border-neutral-100 p-2 flex flex-col justify-between">
         <div>
           <div className="flex items-center justify-between mb-2">
@@ -60,20 +55,8 @@ export function LogCard({ ...props }: CardProps) {
               {props.location}
             </span>
             <div>
-              <HoverCard>
-                <HoverCardTrigger>
-                  <LightbulbOff className="h-4 w-4 ml-2 hover:text-[#ff5544]" />
-                  <span className="sr-only">Lights out</span>
-                </HoverCardTrigger>
-                <HoverCardContent>
-                  <div className="text-sm text-foreground">
-                    This area hasn't had light in the past hour.{" "}
-                    <span className="underline underline-offset-2">
-                      Learn More.
-                    </span>
-                  </div>
-                </HoverCardContent>
-              </HoverCard>
+              <LightbulbOff className="h-4 w-4 ml-2 hover:text-[#ff5544]" />
+              <span className="sr-only">Lights out</span>
             </div>
           </div>
           <div className="flex items-center gap-2">

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as AvatarPrimitive from "@radix-ui/react-avatar"
+import * as React from "react";
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const Avatar = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Root>,
@@ -17,8 +17,8 @@ const Avatar = React.forwardRef<
     )}
     {...props}
   />
-))
-Avatar.displayName = AvatarPrimitive.Root.displayName
+));
+Avatar.displayName = AvatarPrimitive.Root.displayName;
 
 const AvatarImage = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Image>,
@@ -29,8 +29,8 @@ const AvatarImage = React.forwardRef<
     className={cn("aspect-square h-full w-full", className)}
     {...props}
   />
-))
-AvatarImage.displayName = AvatarPrimitive.Image.displayName
+));
+AvatarImage.displayName = AvatarPrimitive.Image.displayName;
 
 const AvatarFallback = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Fallback>,
@@ -44,7 +44,7 @@ const AvatarFallback = React.forwardRef<
     )}
     {...props}
   />
-))
-AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+));
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
 
-export { Avatar, AvatarImage, AvatarFallback }
+export { Avatar, AvatarImage, AvatarFallback };

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -1,13 +1,13 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
+import * as React from "react";
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const HoverCard = HoverCardPrimitive.Root
+const HoverCard = HoverCardPrimitive.Root;
 
-const HoverCardTrigger = HoverCardPrimitive.Trigger
+const HoverCardTrigger = HoverCardPrimitive.Trigger;
 
 const HoverCardContent = React.forwardRef<
   React.ElementRef<typeof HoverCardPrimitive.Content>,
@@ -23,7 +23,7 @@ const HoverCardContent = React.forwardRef<
     )}
     {...props}
   />
-))
-HoverCardContent.displayName = HoverCardPrimitive.Content.displayName
+));
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
 
-export { HoverCard, HoverCardTrigger, HoverCardContent }
+export { HoverCard, HoverCardTrigger, HoverCardContent };


### PR DESCRIPTION
I removed the hovercard component wrapping around the lightbulb icon on the log-card. It was the root of the hydration error.
If feature is relevant enough, we'll figure out how to bring it back without any issues.